### PR TITLE
remove spammy log producer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -75,9 +75,6 @@ def tag_nodes():
 
             time.sleep(0.5)
 
-        else:
-            print node['name'] + ' has all labels.'
-
 while True:
     try:
         time.sleep(30)


### PR DESCRIPTION
If node has all labels there is no need to log it - with enough nodes in the cluster this results in a huge stream of "<node> has all labels" log entries. 